### PR TITLE
Feature/deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+run-dev:
+	REACT_APP_GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
+	REACT_APP_GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
+	REACT_APP_GIT_REVISION=$(shell git rev-parse --short HEAD) \
+	yarn start
+
+run-build-noindex:
+	REACT_APP_GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
+	REACT_APP_GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
+	REACT_APP_GIT_REVISION=$(shell git rev-parse --short HEAD) \
+	yarn build-noindex

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build-ci": "CI= react-scripts build",
+    "build-noindex": "react-scripts build && echo 'User-agent: *\nDisallow: /' | cat > build/robots.txt && echo '/* /index.html  200' | cat >build/_redirects",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -34,3 +34,9 @@ class App extends React.Component {
 
 ReactDOM.render(<App />, document.getElementById('root'));
 //registerServiceWorker();
+
+console.info('version',
+  process.env.REACT_APP_GIT_TAG,
+  process.env.REACT_APP_GIT_BRANCH,
+  `\nhttps://github.com/C2DH/statec-exhibit/commit/${process.env.REACT_APP_GIT_REVISION}`
+)

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -84,8 +84,8 @@ const Home = () => {
             <div className="mw9 center pa4 pt5-ns ph5-l">
               <h2 className="f2-ns f3 fw1 lh-title tc">
                 Through the categories they offer, they made things visible but
-                hide others. Telling the history of how a territory was “put
-                into numbers” over the last 200 years makes unveil the different
+                hid others. Telling the history of how a territory was “put
+                into numbers” over the last 200 years unveils the different
                 stories that the Luxembourg state choose to tell.
               </h2>
             </div>


### PR DESCRIPTION
Add custom script to deploy on netlify. Add _redirect file automatically to build in order to maintain react router browsing.
Current deployment:

added a makefile (unix only). Build with:
```sh
make run-build-noindex
```
then:
```sh
netlify deploy --prod
```